### PR TITLE
Ajuste maxWidth Alert

### DIFF
--- a/src/features/Alert.jsx
+++ b/src/features/Alert.jsx
@@ -1,7 +1,11 @@
 import BAlert from "react-bootstrap/Alert";
 const Alert = ({ variant, message }) => {
   return (
-    <BAlert variant={variant} className="mb-0 text-center">
+    <BAlert
+      variant={variant}
+      className="mb-0 text-center"
+      style={{ maxWidth: "17em" }}
+    >
       {<p className="mb-0 fw-bold">{message}</p>}
     </BAlert>
   );


### PR DESCRIPTION
Se hace un pequeño ajuste al ancho maximo del componente alert, para evitar un pequeño bug que mueve el componente completo en algunas resoluciones. 

![image](https://github.com/achaverrar/adl-base-datos-colaboradores/assets/109968115/573a9e20-1357-48ad-b5ee-cf043d5b7c1b)


![image](https://github.com/achaverrar/adl-base-datos-colaboradores/assets/109968115/0ce83900-04f0-433e-9a8f-741149e24dd3)

